### PR TITLE
喜报的一些小改善

### DIFF
--- a/plugins/xibao/src/index.ts
+++ b/plugins/xibao/src/index.ts
@@ -112,18 +112,16 @@ function html(params: {
     </style>
   </head>
   <body>
-    <div>${params.text.replaceAll('\n', '</div><div>')}</div>
+    <div>${params.text.replaceAll('\n', '<br/>')}</div>
   </body>
   <script>
     const dom = document.querySelector('body')
-    const divs = dom.querySelectorAll('div')
+    const div = dom.querySelectorAll('div')[0]
     let fontSize = ${params.maxFontSize}
     dom.style.fontSize = fontSize + 'px'
-    divs.forEach(div => {
-      while (div.offsetWidth >= ${params.offsetWidth} && fontSize > ${params.minFontSize}) {
-        dom.style.fontSize = --fontSize + 'px'
-      }
-    })
+    while (div.offsetWidth >= ${params.offsetWidth} && fontSize > ${params.minFontSize}) {
+      dom.style.fontSize = --fontSize + 'px'
+    }
   </script>
 </html>`
 }

--- a/plugins/xibao/src/index.ts
+++ b/plugins/xibao/src/index.ts
@@ -116,7 +116,7 @@ function html(params: {
   </body>
   <script>
     const dom = document.querySelector('body')
-    const div = dom.querySelectorAll('div')[0]
+    const div = dom.querySelector('div')
     let fontSize = ${params.maxFontSize}
     dom.style.fontSize = fontSize + 'px'
     while (div.offsetWidth >= ${params.offsetWidth} && fontSize > ${params.minFontSize}) {


### PR DESCRIPTION
简化了 HTML 中用于计算字体大小的代码。换行其实只用 `<br/>` 就可以实现，这样可以把所有的文字放在一个 div 里，也就不需要在计算字体大小时使用 forEach 了。

使用 URI 加载图片，这样可以使插件不需要把图片读进来就能传递给浏览器。由于反斜杠 `\` 在 CSS 中有转义作用，这里将其替换，避免在 Windows 平台上找不到图片。